### PR TITLE
Clamp attributes and add XP debug tooling

### DIFF
--- a/GAS/Config/DefaultGame.ini
+++ b/GAS/Config/DefaultGame.ini
@@ -5,3 +5,8 @@ ProjectName=Third Person BP Game Template
 [/Script/GAS.ExecCalc_AddXP]
 XPRequirementCurve=/Game/GAS/Curves/XPRequirementCurve
 MaxLevel=100
+
+[/Script/GameplayAbilities.AbilitySystemGlobals]
+AbilitySystemGlobalsClassName="/Script/RPGSystems.RPGAbilitySystemGlobals"
++GameplayCueNotifyPaths="/Game/GAS/Cues"
+ReplicateActivationOwnedTags=True

--- a/GAS/Source/GAS/AttributeSets/BasicAttributeSet.cpp
+++ b/GAS/Source/GAS/AttributeSets/BasicAttributeSet.cpp
@@ -1,33 +1,131 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
-
-
 #include "BasicAttributeSet.h"
-#include "Net/UnrealNetwork.h"
 
+#include "GameplayEffectExtension.h"
+#include "Net/UnrealNetwork.h"
 
 UBasicAttributeSet::UBasicAttributeSet()
 {
-	// Initialize attributes with default values
-	Health = 50.f;
-	MaxHealth = 100.f;
-	Mana = 100.f;
-	MaxMana = 100.f;
-	Stamina = 100.f;
-	MaxStamina = 100.f;	
+        // Initialize attributes with default values
+        Health = 50.f;
+        MaxHealth = 100.f;
+        Mana = 100.f;
+        MaxMana = 100.f;
+        Stamina = 100.f;
+        MaxStamina = 100.f;
 }
 
 void UBasicAttributeSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
-	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+        Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Health, COND_None, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxHealth, COND_None, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Stamina, COND_None, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxStamina, COND_None, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Mana, COND_None, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxMana, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Health, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxHealth, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Stamina, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxStamina, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, Mana, COND_None, REPNOTIFY_Always);
+        DOREPLIFETIME_CONDITION_NOTIFY(UBasicAttributeSet, MaxMana, COND_None, REPNOTIFY_Always);
 }
 
+void UBasicAttributeSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
+{
+        Super::PreAttributeChange(Attribute, NewValue);
 
+        if (Attribute == GetMaxHealthAttribute())
+        {
+                const float ClampedMax = FMath::Max(1.f, NewValue);
+                AdjustAttributeForMaxChange(Health, MaxHealth, ClampedMax, GetHealthAttribute());
+                NewValue = ClampedMax;
+        }
+        else if (Attribute == GetMaxManaAttribute())
+        {
+                const float ClampedMax = FMath::Max(0.f, NewValue);
+                AdjustAttributeForMaxChange(Mana, MaxMana, ClampedMax, GetManaAttribute());
+                NewValue = ClampedMax;
+        }
+        else if (Attribute == GetMaxStaminaAttribute())
+        {
+                const float ClampedMax = FMath::Max(0.f, NewValue);
+                AdjustAttributeForMaxChange(Stamina, MaxStamina, ClampedMax, GetStaminaAttribute());
+                NewValue = ClampedMax;
+        }
+        else if (Attribute == GetHealthAttribute())
+        {
+                NewValue = FMath::Clamp(NewValue, 0.f, FMath::Max(GetMaxHealth(), 0.f));
+        }
+        else if (Attribute == GetManaAttribute())
+        {
+                NewValue = FMath::Clamp(NewValue, 0.f, FMath::Max(GetMaxMana(), 0.f));
+        }
+        else if (Attribute == GetStaminaAttribute())
+        {
+                NewValue = FMath::Clamp(NewValue, 0.f, FMath::Max(GetMaxStamina(), 0.f));
+        }
+}
 
+void UBasicAttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
+{
+        Super::PostGameplayEffectExecute(Data);
 
+        if (Data.EvaluatedData.Attribute == GetHealthAttribute())
+        {
+                ClampAttribute(Health, 0.f, FMath::Max(GetMaxHealth(), 0.f), GetHealthAttribute());
+        }
+        else if (Data.EvaluatedData.Attribute == GetManaAttribute())
+        {
+                ClampAttribute(Mana, 0.f, FMath::Max(GetMaxMana(), 0.f), GetManaAttribute());
+        }
+        else if (Data.EvaluatedData.Attribute == GetStaminaAttribute())
+        {
+                ClampAttribute(Stamina, 0.f, FMath::Max(GetMaxStamina(), 0.f), GetStaminaAttribute());
+        }
+        else if (Data.EvaluatedData.Attribute == GetMaxHealthAttribute())
+        {
+                const float ClampedMax = FMath::Max(1.f, GetMaxHealth());
+                SetMaxHealth(ClampedMax);
+                AdjustAttributeForMaxChange(Health, MaxHealth, ClampedMax, GetHealthAttribute());
+        }
+        else if (Data.EvaluatedData.Attribute == GetMaxManaAttribute())
+        {
+                const float ClampedMax = FMath::Max(0.f, GetMaxMana());
+                SetMaxMana(ClampedMax);
+                AdjustAttributeForMaxChange(Mana, MaxMana, ClampedMax, GetManaAttribute());
+        }
+        else if (Data.EvaluatedData.Attribute == GetMaxStaminaAttribute())
+        {
+                const float ClampedMax = FMath::Max(0.f, GetMaxStamina());
+                SetMaxStamina(ClampedMax);
+                AdjustAttributeForMaxChange(Stamina, MaxStamina, ClampedMax, GetStaminaAttribute());
+        }
+}
+
+void UBasicAttributeSet::AdjustAttributeForMaxChange(FGameplayAttributeData& AffectedAttribute, const FGameplayAttributeData& MaxAttribute, float NewMaxValue, const FGameplayAttribute& AffectedAttributeProperty)
+{
+        const float EffectiveMax = FMath::Max(0.f, NewMaxValue);
+        ClampAttribute(AffectedAttribute, 0.f, EffectiveMax, AffectedAttributeProperty);
+}
+
+void UBasicAttributeSet::ClampAttribute(FGameplayAttributeData& AttributeData, float MinValue, float MaxValue, const FGameplayAttribute& AttributeProperty)
+{
+        const float EffectiveMax = FMath::Max(MinValue, MaxValue);
+        const float CurrentValue = AttributeData.GetCurrentValue();
+        const float ClampedCurrentValue = FMath::Clamp(CurrentValue, MinValue, EffectiveMax);
+
+        if (!FMath::IsNearlyEqual(CurrentValue, ClampedCurrentValue))
+        {
+                if (UAbilitySystemComponent* ASC = GetOwningAbilitySystemComponent())
+                {
+                        ASC->ApplyModToAttributeUnsafe(AttributeProperty, EGameplayModOp::Additive, ClampedCurrentValue - CurrentValue);
+                }
+                else
+                {
+                        AttributeData.SetCurrentValue(ClampedCurrentValue);
+                }
+        }
+
+        const float BaseValue = AttributeData.GetBaseValue();
+        const float ClampedBaseValue = FMath::Clamp(BaseValue, MinValue, EffectiveMax);
+        if (!FMath::IsNearlyEqual(BaseValue, ClampedBaseValue))
+        {
+                AttributeData.SetBaseValue(ClampedBaseValue);
+        }
+}

--- a/GAS/Source/GAS/AttributeSets/BasicAttributeSet.h
+++ b/GAS/Source/GAS/AttributeSets/BasicAttributeSet.h
@@ -1,5 +1,3 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
 #include "CoreMinimal.h"
@@ -7,83 +5,96 @@
 #include "AbilitySystemComponent.h"
 #include "BasicAttributeSet.generated.h"
 
-/**
- * 
- */
+struct FGameplayEffectModCallbackData;
+
+#ifndef ATTRIBUTE_ACCESSORS_BASIC
+#define ATTRIBUTE_ACCESSORS_BASIC(ClassName, PropertyName) \
+        GAMEPLAYATTRIBUTE_PROPERTY_GETTER(ClassName, PropertyName) \
+        GAMEPLAYATTRIBUTE_VALUE_GETTER(PropertyName) \
+        GAMEPLAYATTRIBUTE_VALUE_SETTER(PropertyName) \
+        GAMEPLAYATTRIBUTE_VALUE_INITTER(PropertyName)
+#endif
+
 UCLASS()
 class GAS_API UBasicAttributeSet : public UAttributeSet
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
+        UBasicAttributeSet();
 
-	UBasicAttributeSet();
+        //Health
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_Health)
+        FGameplayAttributeData Health;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Health);
 
-	//Health
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_Health)
-	FGameplayAttributeData Health;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Health);
-	
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_MaxHealth)
-	FGameplayAttributeData MaxHealth;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxHealth);
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_MaxHealth)
+        FGameplayAttributeData MaxHealth;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxHealth);
 
-	// Mana
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_Mana)
-	FGameplayAttributeData Mana;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Mana);
-	
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_MaxMana)
-	FGameplayAttributeData MaxMana;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxMana);
-	
-	//Stamina
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_Stamina)
-	FGameplayAttributeData Stamina;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Stamina);
+        // Mana
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_Mana)
+        FGameplayAttributeData Mana;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Mana);
 
-	UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing=OnRep_MaxStamina)
-	FGameplayAttributeData MaxStamina;
-	ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxStamina);
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_MaxMana)
+        FGameplayAttributeData MaxMana;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxMana);
+
+        //Stamina
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_Stamina)
+        FGameplayAttributeData Stamina;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, Stamina);
+
+        UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_MaxStamina)
+        FGameplayAttributeData MaxStamina;
+        ATTRIBUTE_ACCESSORS_BASIC(UBasicAttributeSet, MaxStamina);
 
 public:
-	//Funtions OnRep
-	UFUNCTION()
-	void OnRep_Health(const FGameplayAttributeData& OldHealth) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Health, OldHealth);
-	}
-	
-	UFUNCTION()
-	void OnRep_MaxHealth(const FGameplayAttributeData& OldMaxHealth) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxHealth, OldMaxHealth);
-	}
-	
-	UFUNCTION()
-	void OnRep_Stamina(const FGameplayAttributeData& OldStamina) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Stamina, OldStamina);
-	}
-	
-	UFUNCTION()
-	void OnRep_MaxStamina(const FGameplayAttributeData& OldMaxStamina) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxStamina, OldMaxStamina);
-	}
+        //Funtions OnRep
+        UFUNCTION()
+        void OnRep_Health(const FGameplayAttributeData& OldHealth) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Health, OldHealth);
+        }
 
-	UFUNCTION()
-	void OnRep_Mana(const FGameplayAttributeData& OldMana) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Mana, OldMana);
-	}
-	
-	UFUNCTION()
-	void OnRep_MaxMana(const FGameplayAttributeData& OldMaxMana) const
-	{
-		GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxMana, OldMaxMana);
-	}
+        UFUNCTION()
+        void OnRep_MaxHealth(const FGameplayAttributeData& OldMaxHealth) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxHealth, OldMaxHealth);
+        }
 
-	// Override GetLifetimeReplicatedProps
-	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+        virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
+        virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
+
+        UFUNCTION()
+        void OnRep_Stamina(const FGameplayAttributeData& OldStamina) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Stamina, OldStamina);
+        }
+
+        UFUNCTION()
+        void OnRep_MaxStamina(const FGameplayAttributeData& OldMaxStamina) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxStamina, OldMaxStamina);
+        }
+
+        UFUNCTION()
+        void OnRep_Mana(const FGameplayAttributeData& OldMana) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, Mana, OldMana);
+        }
+
+        UFUNCTION()
+        void OnRep_MaxMana(const FGameplayAttributeData& OldMaxMana) const
+        {
+                GAMEPLAYATTRIBUTE_REPNOTIFY(UBasicAttributeSet, MaxMana, OldMaxMana);
+        }
+
+        // Override GetLifetimeReplicatedProps
+        virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+private:
+        void AdjustAttributeForMaxChange(FGameplayAttributeData& AffectedAttribute, const FGameplayAttributeData& MaxAttribute, float NewMaxValue, const FGameplayAttribute& AffectedAttributeProperty);
+        void ClampAttribute(FGameplayAttributeData& AttributeData, float MinValue, float MaxValue, const FGameplayAttribute& AttributeProperty);
 };

--- a/GAS/Source/GAS/Character/CharacterBase.cpp
+++ b/GAS/Source/GAS/Character/CharacterBase.cpp
@@ -16,9 +16,26 @@ ACharacterBase::ACharacterBase()
 	PrimaryActorTick.bCanEverTick = true;
 
 	// Add Ability System Component
-	AbilitySystemComponent = CreateDefaultSubobject<UAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
-	AbilitySystemComponent->SetIsReplicated(true);
-	AbilitySystemComponent->SetReplicationMode(AscReplicationMode);
+        AbilitySystemComponent = CreateDefaultSubobject<UAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
+
+        BasicAttributeSet = CreateDefaultSubobject<UBasicAttributeSet>(TEXT("BasicAttributeSet"));
+        ProgressionAttributeSet = CreateDefaultSubobject<UProgressionAttributeSet>(TEXT("ProgressionAttributeSet"));
+
+        if (AbilitySystemComponent)
+        {
+                AbilitySystemComponent->SetIsReplicated(true);
+                AbilitySystemComponent->SetReplicationMode(AscReplicationMode);
+
+                if (BasicAttributeSet)
+                {
+                        AbilitySystemComponent->AddAttributeSetSubobject(BasicAttributeSet);
+                }
+
+                if (ProgressionAttributeSet)
+                {
+                        AbilitySystemComponent->AddAttributeSetSubobject(ProgressionAttributeSet);
+                }
+        }
 
 	//set size for collision capsule
 	GetCapsuleComponent()->InitCapsuleSize(35.f, 90.0f);
@@ -40,8 +57,6 @@ ACharacterBase::ACharacterBase()
 	GetCharacterMovement()->BrakingDecelerationFalling = 1500.f;
 	
         // Attribute sets
-        //BasicAttributeSet = CreateDefaultSubobject<UBasicAttributeSet>(TEXT("BasicAttributeSet"));
-        ProgressionAttributeSet = CreateDefaultSubobject<UProgressionAttributeSet>(TEXT("ProgressionAttributeSet"));
 }
 
 
@@ -126,6 +141,11 @@ void ACharacterBase::GrantExperience(float Amount)
         Spec->SetLevel(1.f);
         Spec->SetSetByCallerMagnitude(DataXPTag, ClampedAmount);
         AbilitySystemComponent->ApplyGameplayEffectSpecToSelf(*Spec);
+}
+
+void ACharacterBase::ServerGrantExperience_Implementation(float Amount)
+{
+        GrantExperience(Amount);
 }
 
 // Called when the game starts or when spawned

--- a/GAS/Source/GAS/Character/CharacterBase.h
+++ b/GAS/Source/GAS/Character/CharacterBase.h
@@ -39,6 +39,9 @@ public:
         UFUNCTION(BlueprintCallable, Category = "GAS|Progression")
         void GrantExperience(float Amount);
 
+        UFUNCTION(Server, Reliable)
+        void ServerGrantExperience(float Amount);
+
 protected:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GAS")

--- a/GAS/Source/GAS/GAS.cpp
+++ b/GAS/Source/GAS/GAS.cpp
@@ -1,6 +1,60 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #include "GAS.h"
 #include "Modules/ModuleManager.h"
+#include "HAL/IConsoleManager.h"
+#include "Engine/World.h"
+#include "GAS/Character/CharacterBase.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Pawn.h"
+
+namespace GASConsoleCommands
+{
+        static void GrantXPCommandHandler(const TArray<FString>& Args, UWorld* World)
+        {
+                if (!World)
+                {
+                        return;
+                }
+
+                if (Args.Num() == 0)
+                {
+                        UE_LOG(LogTemp, Warning, TEXT("Usage: GAS.GrantXP <Amount>"));
+                        return;
+                }
+
+                const float Amount = FCString::Atof(*Args[0]);
+                if (Amount <= 0.f)
+                {
+                        UE_LOG(LogTemp, Warning, TEXT("GAS.GrantXP requires a positive amount."));
+                        return;
+                }
+
+                for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It)
+                {
+                        APlayerController* PlayerController = It->Get();
+                        if (!PlayerController)
+                        {
+                                continue;
+                        }
+
+                        APawn* Pawn = PlayerController->GetPawn();
+                        if (ACharacterBase* Character = Cast<ACharacterBase>(Pawn))
+                        {
+                                if (Character->HasAuthority())
+                                {
+                                        Character->GrantExperience(Amount);
+                                }
+                                else
+                                {
+                                        Character->ServerGrantExperience(Amount);
+                                }
+                        }
+                }
+        }
+
+        static FAutoConsoleCommandWithWorldAndArgs GrantXPConsoleCommand(
+                TEXT("GAS.GrantXP"),
+                TEXT("Grants experience to all possessed GAS characters. Usage: GAS.GrantXP <Amount>"),
+                FConsoleCommandWithWorldAndArgsDelegate::CreateStatic(&GrantXPCommandHandler));
+}
 
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, GAS, "GAS" );


### PR DESCRIPTION
## Summary
- clamp health, mana, and stamina within their maxima during attribute changes and gameplay effect execution
- register the basic and progression attribute sets with the ability system component to eliminate duplicate debug output
- expose a GAS.GrantXP console command backed by a server RPC for granting experience during level-up testing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b2b20174833081c17ef1890099ca